### PR TITLE
页面报错会导致截图卡住

### DIFF
--- a/phantom/web_camera_phantom.js
+++ b/phantom/web_camera_phantom.js
@@ -193,6 +193,11 @@ setTimeout(function () {
   finish(timeout + 'ms timeout to finish');
 }, timeout);
 
+// 当页面未加载完，open 的回调一直未执行导致卡死，绑定 onError 可以解决这个问题
+page.onError = function(msg) {
+  log('onError ' + msg);
+};
+
 page.open(address, function (status) {
   log('open status: ' + status);
   if (status !== 'success' && !_done) {

--- a/test/web_camera.test.js
+++ b/test/web_camera.test.js
@@ -103,6 +103,16 @@ describe('lib/web_camera.js', function () {
         done();
       });
     });
+
+    it('should return when page has error', function(done) {
+      camera = Camera.create();
+      camera.shot('https://os.alipayobjects.com/rmsportal/UKYoZFxFsmwxVjB.html', './test.png', function (err, data) {
+        data.should.include('test.png');
+        fs.existsSync(data).should.be.ok;
+        fs.unlinkSync(data);
+        done(err);
+      });
+    });
   });
 
   describe('#shotStream', function () {


### PR DESCRIPTION
页面报错时，`page.open` 时触发不了回调，导致进程卡住，无法退出。增加绑定 `page.onError` 可以避免这个问题。